### PR TITLE
Close Signal Logging on Disable

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -2,6 +2,7 @@ import urcl
 import wpilib
 from commands2 import CommandScheduler, TimedCommandRobot
 
+from subsystems.sysid_subsystem import SysidSubsystem
 from sysidroutinebot import SysIdRoutineBot
 
 
@@ -15,3 +16,6 @@ class MyRobot(TimedCommandRobot):
 
     def teleopInit(self) -> None:
         CommandScheduler.getInstance().cancelAll()
+
+    def disabledInit(self) -> None:
+        SysidSubsystem().stopLogging()

--- a/robot.py
+++ b/robot.py
@@ -18,4 +18,4 @@ class MyRobot(TimedCommandRobot):
         CommandScheduler.getInstance().cancelAll()
 
     def disabledInit(self) -> None:
-        SysidSubsystem().stopLogging()
+        SysidSubsystem.stopLogging()

--- a/subsystems/sysid_subsystem.py
+++ b/subsystems/sysid_subsystem.py
@@ -41,8 +41,10 @@ class SysidSubsystem(Subsystem):
         )
         self.sys_id_routine.recordState(state)
 
-    def stopLogging(self) -> None:
+    @classmethod
+    def stopLogging(cls) -> None:
         SignalLogger.stop()
+        SysidSubsystem.logger_inited = False
 
     def defaultCommand(self) -> Command:
         return self.run(lambda: None)

--- a/subsystems/sysid_subsystem.py
+++ b/subsystems/sysid_subsystem.py
@@ -41,6 +41,9 @@ class SysidSubsystem(Subsystem):
         )
         self.sys_id_routine.recordState(state)
 
+    def stopLogging(self) -> None:
+        SignalLogger.stop()
+
     def defaultCommand(self) -> Command:
         return self.run(lambda: None)
 


### PR DESCRIPTION
From what I see, we never call `SignalLogger.stop()` after we're done logging. I believe this is the reason there's a good chance it's the reason some of our files result in "corrupted" errors when trying to convert them in Phoneix Tuner 